### PR TITLE
Add server's IP address to configuration file

### DIFF
--- a/wireguard_server.sh
+++ b/wireguard_server.sh
@@ -27,6 +27,7 @@ cat > ${config_file} << EOF
 [Interface]
 PrivateKey = ${server_private}
 ListenPort = ${server_port}
+# 10.0.0.1
 EOF
 
 cat > /etc/hostname.${interface} << EOF


### PR DESCRIPTION
wireguard_client.sh expects there to be an IP address on the last line
of the configuration file, this breaks on the initial client to be
added as there is none on the last line of the file.

This commit adds the server's expected IP address so the rest are
automatically incremented.